### PR TITLE
Improve tests and extend TableIOPlugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@ Wisconsin-Madison and University of Konstanz.</license.copyrightOwners>
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 		<scijava-table.version>0.6.0</scijava-table.version>
+		<scijava-optional.version>1.0.0</scijava-optional.version>
 	</properties>
 
 	<dependencies>
@@ -110,7 +111,7 @@ Wisconsin-Madison and University of Konstanz.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-optional</artifactId>
-			<version>1.0.0</version>
+			<version>${scijava-optional.version}</version>
 		</dependency>
 
 		<!-- Test scope dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>28.0.0</version>
+		<version>29.0.0-beta-3</version>
 		<relativePath />
 	</parent>
 
@@ -95,6 +95,7 @@ Wisconsin-Madison and University of Konstanz.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+		<scijava-table.version>0.6.0</scijava-table.version>
 	</properties>
 
 	<dependencies>
@@ -105,6 +106,11 @@ Wisconsin-Madison and University of Konstanz.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-table</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-optional</artifactId>
+			<version>1.0.0</version>
 		</dependency>
 
 		<!-- Test scope dependencies -->

--- a/src/main/java/org/scijava/table/DefaultTableIOPlugin.java
+++ b/src/main/java/org/scijava/table/DefaultTableIOPlugin.java
@@ -256,10 +256,6 @@ public class DefaultTableIOPlugin extends TableIOPlugin {
 			Double.valueOf(content);
 			return Double::valueOf;
 		} catch(NumberFormatException ignored) {}
-		try {
-			Float.valueOf(content);
-			return Float::valueOf;
-		} catch(NumberFormatException ignored) {}
 		if(content.equalsIgnoreCase("true")||content.equalsIgnoreCase("false")) {
 			return Boolean::valueOf;
 		}

--- a/src/main/java/org/scijava/table/DefaultTableIOPlugin.java
+++ b/src/main/java/org/scijava/table/DefaultTableIOPlugin.java
@@ -269,17 +269,7 @@ public class DefaultTableIOPlugin extends TableIOPlugin {
 	@Override
 	public void save(final Table table, final String destination)
 			throws IOException {
-		TableIOOptions options = new TableIOOptions();
-		// DISCUSS if we guess at his point if column or row headers should be written, the plugin will behave differently
-		// if you call save(table, destination) vs. save(table, destination, new TableIOOptions())
-		// .. and this seems just wrong.
-//		options.writeColHeaders(table.getColumnCount() > 0 && //
-//				IntStream.range(0, table.getColumnCount()).allMatch(col -> table
-//						.getColumnHeader(col) != null));
-//		options.writeRowHeaders(table.getRowCount() > 0 && //
-//				IntStream.range(0, table.getRowCount()).allMatch(row -> table
-//						.getRowHeader(row) != null));
-		save(table, destination, options.values);
+		save(table, destination, new TableIOOptions().values);
 	}
 
 	@Override

--- a/src/test/java/org/scijava/table/DefaultTableIOPluginTest.java
+++ b/src/test/java/org/scijava/table/DefaultTableIOPluginTest.java
@@ -254,6 +254,7 @@ public class DefaultTableIOPluginTest {
 		assertEquals(false, DefaultTableIOPlugin.guessParser("false").apply("false"));
 		assertEquals(123.0, DefaultTableIOPlugin.guessParser("123.0").apply("123.0"));
 		assertEquals(-123.0, DefaultTableIOPlugin.guessParser("-123.0").apply("-123.0"));
+		assertEquals(3, DefaultTableIOPlugin.guessParser("3").apply("3"));
 		assertEquals(1234567890.0987654321, DefaultTableIOPlugin.guessParser("1.2345678900987654E9").apply("1.2345678900987654E9"));
 		assertEquals(Double.NaN, DefaultTableIOPlugin.guessParser("NaN").apply("NaN"));
 		assertEquals(Double.NEGATIVE_INFINITY, DefaultTableIOPlugin.guessParser("-Infinity").apply("-Infinity"));

--- a/src/test/java/org/scijava/table/DefaultTableIOPluginTest.java
+++ b/src/test/java/org/scijava/table/DefaultTableIOPluginTest.java
@@ -255,6 +255,7 @@ public class DefaultTableIOPluginTest {
 		assertEquals(123.0, DefaultTableIOPlugin.guessParser("123.0").apply("123.0"));
 		assertEquals(-123.0, DefaultTableIOPlugin.guessParser("-123.0").apply("-123.0"));
 		assertEquals(3, DefaultTableIOPlugin.guessParser("3").apply("3"));
+		assertEquals(36564573745634564L, DefaultTableIOPlugin.guessParser("36564573745634564").apply("36564573745634564"));
 		assertEquals(1234567890.0987654321, DefaultTableIOPlugin.guessParser("1.2345678900987654E9").apply("1.2345678900987654E9"));
 		assertEquals(Double.NaN, DefaultTableIOPlugin.guessParser("NaN").apply("NaN"));
 		assertEquals(Double.NEGATIVE_INFINITY, DefaultTableIOPlugin.guessParser("-Infinity").apply("-Infinity"));

--- a/src/test/java/org/scijava/table/DefaultTableIOPluginTest.java
+++ b/src/test/java/org/scijava/table/DefaultTableIOPluginTest.java
@@ -311,21 +311,6 @@ public class DefaultTableIOPluginTest {
 		return result;
 	}
 
-	private void setValues(final Object instance, final String[] fieldNames,
-		final Object[] values) throws SecurityException
-	{
-		final Class<?> cls = instance.getClass();
-		final List<Field> fields = ClassUtils.getAnnotatedFields(cls,
-			Parameter.class);
-		final HashMap<String, Field> fieldMap = new HashMap<>();
-		for (final Field field : fields) {
-			fieldMap.put(field.getName(), field);
-		}
-		for (int i = 0; i < fieldNames.length; i++) {
-			ClassUtils.setValue(fieldMap.get(fieldNames[i]), instance, values[i]);
-		}
-	}
-
 	private String makeTableSource(final String[][] cells, final String separator,
 		final String eol)
 	{


### PR DESCRIPTION
This PR is addressing https://github.com/scijava/scijava-table/issues/22 and making the `DefaultTableIOPlugin` compatible with the latest `scijava-table` version.

Changes:
- fix tests to test default behaviour & API options instead of changing parameters via reflection
- read and write row and column headers by default
- `DefaultTableIOPlugin` extends `TableIOPlugin`
- removed the plugin parameters, making use of `TableIOOptions` instead
- guess column types based on first data row