### PR TITLE
Use Location instead of String

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>29.2.0</version>
+		<version>29.2.1</version>
 		<relativePath />
 	</parent>
 
 	<artifactId>scijava-plugins-io-table</artifactId>
-	<version>0.3.1-SNAPSHOT</version>
+	<version>0.4.0-SNAPSHOT</version>
 
 	<name>SciJava IO Plugin: Tables</name>
 	<description>I/O plugins for SciJava table objects.</description>
@@ -100,7 +100,8 @@ Wisconsin-Madison and University of Konstanz.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
-		<scijava-table.version>0.6.1</scijava-table.version>
+		<scijava-table.version>0.7.0</scijava-table.version>
+		<scijava-common.version>2.84.0</scijava-common.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/scijava/table/DefaultTableIOPlugin.java
+++ b/src/main/java/org/scijava/table/DefaultTableIOPlugin.java
@@ -247,18 +247,14 @@ public class DefaultTableIOPlugin extends AbstractIOPlugin<Table> implements Tab
 		return options.parser();
 	}
 
-	static Function<String, Object> guessParser(String content) {
+	static Function<String, ?> guessParser(String content) {
 		try {
-			Integer.valueOf(content);
-			return Integer::valueOf;
-		} catch(NumberFormatException ignored) {}
-		try {
-			Long.valueOf(content);
-			return Long::valueOf;
-		} catch(NumberFormatException ignored) {}
-		try {
-			Double.valueOf(content);
-			return Double::valueOf;
+			Function<String, ?> function = s -> Double.valueOf(s
+					.replace("infinity", "Infinity")
+					.replace("Nan", "NaN")
+			);
+			function.apply(content);
+			return function;
 		} catch(NumberFormatException ignored) {}
 		if(content.equalsIgnoreCase("true")||content.equalsIgnoreCase("false")) {
 			return Boolean::valueOf;

--- a/src/main/java/org/scijava/table/DefaultTableIOPlugin.java
+++ b/src/main/java/org/scijava/table/DefaultTableIOPlugin.java
@@ -30,7 +30,6 @@
 
 package org.scijava.table;
 
-import java.net.URISyntaxException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,11 +42,10 @@ import java.util.Set;
 import java.util.function.Function;
 
 import org.scijava.Priority;
-import org.scijava.io.IOPlugin;
+import org.scijava.io.AbstractIOPlugin;
 import org.scijava.io.handle.DataHandle;
 import org.scijava.io.handle.DataHandleService;
 import org.scijava.io.location.Location;
-import org.scijava.io.location.LocationService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.table.io.ColumnTableIOOptions;
@@ -61,11 +59,8 @@ import org.scijava.util.FileUtils;
  * @author Leon Yang
  */
 @SuppressWarnings("rawtypes")
-@Plugin(type = IOPlugin.class, priority = Priority.LOW)
-public class DefaultTableIOPlugin extends TableIOPlugin {
-
-	@Parameter
-	private LocationService locationService;
+@Plugin(type = TableIOPlugin.class, priority = Priority.LOW)
+public class DefaultTableIOPlugin extends AbstractIOPlugin<Table> implements TableIOPlugin {
 
 	@Parameter
 	private DataHandleService dataHandleService;
@@ -77,9 +72,25 @@ public class DefaultTableIOPlugin extends TableIOPlugin {
 			"rtf")));
 
 	@Override
+	public boolean supportsOpen(final Location source) {
+		final String ext = FileUtils.getExtension(source.getName()).toLowerCase();
+		return SUPPORTED_EXTENSIONS.contains(ext);
+	}
+
+	@Override
 	public boolean supportsOpen(final String source) {
 		final String ext = FileUtils.getExtension(source).toLowerCase();
 		return SUPPORTED_EXTENSIONS.contains(ext);
+	}
+
+	@Override
+	public boolean supportsSave(Object data, String destination) {
+		return supports(destination) && Table.class.isAssignableFrom(data.getClass());
+	}
+
+	@Override
+	public boolean supportsSave(final Location source) {
+		return supportsOpen(source);
 	}
 
 	@Override
@@ -143,23 +154,16 @@ public class DefaultTableIOPlugin extends TableIOPlugin {
 	}
 
 	@Override
-	public GenericTable open(final String source, TableIOOptions options) throws IOException {
+	public GenericTable open(final Location source, TableIOOptions options) throws IOException {
 		return open(source, options.values);
 	}
 
-	private GenericTable open(final String source, TableIOOptions.Values options) throws IOException {
+	private GenericTable open(final Location source, TableIOOptions.Values options) throws IOException {
 
-		final Location sourceLocation;
-		try {
-			sourceLocation = locationService.resolve(source);
-		}
-		catch (final URISyntaxException exc) {
-			throw new IOException("Unresolvable source: " + source, exc);
-		}
 		final GenericTable table = new DefaultGenericTable();
 
 		try (final DataHandle<? extends Location> handle = //
-			dataHandleService.create(sourceLocation))
+			dataHandleService.create(source))
 		{
 			if (!handle.exists()) {
 				throw new IOException("Cannot open source");
@@ -180,7 +184,7 @@ public class DefaultTableIOPlugin extends TableIOPlugin {
 			final String[] lines = text.split("\\R");
 			if (lines.length == 0) return table;
 			// process first line to get number of cols
-			Map<Integer, Function<String, Object>> columnParsers = new HashMap<>();
+			Map<Integer, Function<String, ?>> columnParsers = new HashMap<>();
 			{
 				final ArrayList<String> tokens = processRow(lines[0], separator, quote);
 				if (readColHeaders) {
@@ -203,7 +207,7 @@ public class DefaultTableIOPlugin extends TableIOPlugin {
 						table.appendRow();
 					}
 					for (int i = 0; i < cols.size(); i++) {
-						Function<String, Object> parser = getParser(cols.get(i), i, options);
+						Function<String, ?> parser = getParser(cols.get(i), i, options);
 						columnParsers.put(i, parser);
 						table.set(i, 0, parser.apply(cols.get(i)));
 					}
@@ -236,7 +240,7 @@ public class DefaultTableIOPlugin extends TableIOPlugin {
 		return table;
 	}
 
-	private static Function<String, Object> getParser(String content, int column, TableIOOptions.Values options) {
+	private static Function<String, ?> getParser(String content, int column, TableIOOptions.Values options) {
 		ColumnTableIOOptions.Values colOptions = options.column(column);
 		if(colOptions != null) return colOptions.parser();
 		if(options.guessParser()) return guessParser(content);
@@ -263,29 +267,16 @@ public class DefaultTableIOPlugin extends TableIOPlugin {
 	}
 
 	@Override
-	public void save(final Table table, final String destination)
-			throws IOException {
-		save(table, destination, new TableIOOptions().values);
-	}
-
-	@Override
-	public void save(final Table table, final String destination, final TableIOOptions options)
+	public void save(final Table table, final Location destination, final TableIOOptions options)
 		throws IOException {
 		save(table, destination, options.values);
 	}
 
-	private void save(final Table table, final String destination, final TableIOOptions.Values options)
+	private void save(final Table table, final Location destination, final TableIOOptions.Values options)
 			throws IOException {
-		final Location dstLocation;
-		try {
-			dstLocation = locationService.resolve(destination);
-		}
-		catch (final URISyntaxException exc) {
-			throw new IOException("Unresolvable destination: " + destination, exc);
-		}
 
 		try (final DataHandle<Location> handle = //
-			dataHandleService.create(dstLocation))
+			dataHandleService.create(destination))
 		{
 			final boolean writeRH = options.writeRowHeaders();
 			final boolean writeCH = options.writeColumnHeaders();

--- a/src/test/java/org/scijava/table/DefaultTableIOPluginTest.java
+++ b/src/test/java/org/scijava/table/DefaultTableIOPluginTest.java
@@ -36,10 +36,8 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 
 import org.junit.After;
@@ -52,10 +50,8 @@ import org.scijava.io.handle.DataHandle;
 import org.scijava.io.handle.DataHandleService;
 import org.scijava.io.location.FileLocation;
 import org.scijava.io.location.Location;
-import org.scijava.plugin.Parameter;
 import org.scijava.table.io.TableIOOptions;
 import org.scijava.table.io.TableIOPlugin;
-import org.scijava.util.ClassUtils;
 
 /**
  * Tests for {@link DefaultTableIOPlugin}.
@@ -293,7 +289,7 @@ public class DefaultTableIOPluginTest {
 		tempFiles.add(tempFile);
 		try (DataHandle<Location> destHandle = dataHandleService.create(new FileLocation(tempFile))) {
 			destHandle.write(tableSource.getBytes());
-			result = tableIO.open(tempFile.getAbsolutePath(), options);
+			result = tableIO.open(destHandle.get(), options);
 		}
 		return result;
 	}
@@ -307,7 +303,7 @@ public class DefaultTableIOPluginTest {
 		File tempFile = File.createTempFile("saveTest", ".txt");
 		tempFiles.add(tempFile);
 		try (DataHandle<Location> sourceHandle = dataHandleService.create(new FileLocation(tempFile))) {
-			tableIO.save(table, tempFile.getAbsolutePath(), options);
+			tableIO.save(table, sourceHandle.get(), options);
 			result = sourceHandle.readString(Integer.MAX_VALUE);
 		}
 		return result;

--- a/src/test/java/org/scijava/table/DefaultTableIOPluginTest.java
+++ b/src/test/java/org/scijava/table/DefaultTableIOPluginTest.java
@@ -111,7 +111,7 @@ public class DefaultTableIOPluginTest {
 	}
 
 	/**
-	 * Tests if quoting works in different senarios.
+	 * Tests if quoting works in different scenarios.
 	 */
 	@Test
 	public void testQuote() {
@@ -160,7 +160,7 @@ public class DefaultTableIOPluginTest {
 	}
 
 	/**
-	 * Tests if samll tables could be opened/saved correctly.
+	 * Tests if small tables can be opened/saved correctly.
 	 */
 	@Test
 	public void testSmallTables() {
@@ -250,11 +250,13 @@ public class DefaultTableIOPluginTest {
 		assertEquals(false, DefaultTableIOPlugin.guessParser("false").apply("false"));
 		assertEquals(123.0, DefaultTableIOPlugin.guessParser("123.0").apply("123.0"));
 		assertEquals(-123.0, DefaultTableIOPlugin.guessParser("-123.0").apply("-123.0"));
-		assertEquals(3, DefaultTableIOPlugin.guessParser("3").apply("3"));
-		assertEquals(36564573745634564L, DefaultTableIOPlugin.guessParser("36564573745634564").apply("36564573745634564"));
+		assertEquals(3.0, DefaultTableIOPlugin.guessParser("3").apply("3"));
+		assertEquals(36564573745634564d, DefaultTableIOPlugin.guessParser("36564573745634564").apply("36564573745634564"));
 		assertEquals(1234567890.0987654321, DefaultTableIOPlugin.guessParser("1.2345678900987654E9").apply("1.2345678900987654E9"));
 		assertEquals(Double.NaN, DefaultTableIOPlugin.guessParser("NaN").apply("NaN"));
+		assertEquals(Double.NaN, DefaultTableIOPlugin.guessParser("Nan").apply("Nan"));
 		assertEquals(Double.NEGATIVE_INFINITY, DefaultTableIOPlugin.guessParser("-Infinity").apply("-Infinity"));
+		assertEquals(Double.POSITIVE_INFINITY, DefaultTableIOPlugin.guessParser("infinity").apply("infinity"));
 		assertEquals(0.0, DefaultTableIOPlugin.guessParser("0.0").apply("0.0"));
 	}
 


### PR DESCRIPTION
This PR depends on the following PRs:
- https://github.com/scijava/scijava-common/pull/395
- https://github.com/scijava/scijava-common/pull/396
- https://github.com/scijava/scijava-table/pull/17

It uses `Location` instead of `String` for opening and saving. It also adapts to the change in `TableIOOptions` where the parser is now of type `Function<String, ?>` instead of `Function<String, Object>`.